### PR TITLE
pom.xml: move forward to 5.16.2 and use https for repo1.maven.org

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,13 +19,13 @@
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
-			<version>2.6.0-cdh5.4.4</version>
+			<version>2.6.0-cdh5.16.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-hdfs</artifactId>
-			<version>2.6.0-cdh5.4.4</version>
+			<version>2.6.0-cdh5.16.2</version>
 		</dependency>
 
 		<dependency>
@@ -156,7 +156,7 @@
 		</repository>
 		<repository>
 			<id>central</id>
-			<url>http://repo1.maven.org/maven2/</url>
+			<url>https://repo1.maven.org/maven2/</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>


### PR DESCRIPTION
Two minor changes to pom.xml to enable build against latest CDH as of Feb 2023